### PR TITLE
Don't allow null values for the type column in mooc_blocks. Otherwise, v...

### DIFF
--- a/migrations/004_modify_block_type_column.php
+++ b/migrations/004_modify_block_type_column.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * Currently, the null values are allowed for the type column in the mooc_blocks
+ * table. With this, the default value specified via the default_values property
+ * in the AbstractBlock class is never applied.
+ *
+ * @author Christian Flothmann <cflothma@uos.de>
+ */
+class ModifyBlockTypeColumn extends Migration
+{
+    /**
+     * {@inheritDoc}
+     */
+    function description()
+    {
+        return 'Don\'t allow null values in the type column.';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    function up()
+    {
+        $db = DBManager::get();
+        $db->exec('ALTER TABLE `mooc_blocks` MODIFY `type` VARCHAR(64) NOT NULL');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    function down()
+    {
+        $db = DBManager::get();
+        $db->exec('ALTER TABLE `mooc_blocks` MODIFY `type` VARCHAR(64) NULL');
+    }
+}


### PR DESCRIPTION
...alues derived from the concrete model classes won't be set automatically.
