### PR TITLE
 Methode json_error im MoocIPController ist private

### DIFF
--- a/controllers/moocip_controller.php
+++ b/controllers/moocip_controller.php
@@ -126,7 +126,7 @@ class MoocipController extends StudipController {
     }
 
     // display a JSON error
-    private function json_error($reason, $status = 500, $data = null)
+    protected function json_error($reason, $status = 500, $data = null)
     {
         $this->response->set_status($status);
         $payload = array(


### PR DESCRIPTION
Abgeleitete Klassen können diese Methode demnach nicht verwenden, versuchen es jedoch.
Die Methode json_error sollte mindestens protected sein.