### PR TITLE
Ensure regular whitespace handling for Vips

### DIFF
--- a/blocks/TestBlock/css/test_block.less
+++ b/blocks/TestBlock/css/test_block.less
@@ -150,6 +150,9 @@ section.TestBlock {
       > div {
           padding-left: 0px;
           text-indent: 0px;
+          > span {
+              white-space: normal !important;
+          }
       }
   }
 }


### PR DESCRIPTION
If quiz responses are too long, they might exceed the boundaries of the
quiz block as no wrapping is allowed by default. This commits overwrites
this Vips default, ensuring such lines are wrapped correctly.